### PR TITLE
상단 로고바와 세부화면의 뒤로가기바 구현 완료

### DIFF
--- a/app/src/main/java/com/example/yourtrip/MainActivity.java
+++ b/app/src/main/java/com/example/yourtrip/MainActivity.java
@@ -1,7 +1,10 @@
 package com.example.yourtrip;
 
 import android.os.Bundle;
+import android.view.View;
+import android.widget.LinearLayout;
 
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
@@ -10,11 +13,14 @@ import com.example.yourtrip.feed.FeedFragment;
 import com.example.yourtrip.home.HomeFragment;
 import com.example.yourtrip.mypage.MypageFragment;
 import com.example.yourtrip.mytrip.MytripFragment;
+import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 
 
 public class MainActivity extends AppCompatActivity {
     private BottomNavigationView bottomNav;
+    private MaterialToolbar topNav;
+    private LinearLayout logoContainer;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -22,33 +28,88 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
 
         bottomNav = findViewById(R.id.bottomNav);
+        topNav=findViewById(R.id.topNav);
+        logoContainer = findViewById(R.id.logoContainer);
+
+        // 로고 클릭 시 홈 이동
+        logoContainer.setOnClickListener(v ->
+                bottomNav.setSelectedItemId(R.id.nav_home)
+        );
 
         // 처음 실행 시 홈화면 표시
         if (savedInstanceState == null) {
-            switchFragment(new HomeFragment());
+            switchFragment(new HomeFragment(), false);
+            showLogoBar();
         }
 
-        // 네비게이션 바 클릭 리스너
+        // 하단 네비게이션 바 클릭 리스너
         bottomNav.setOnItemSelectedListener(item -> {
             Fragment target = null;
             int id = item.getItemId();
+
             if (id == R.id.nav_home) target = new HomeFragment();
             else if (id == R.id.nav_trip) target = new MytripFragment();
             else if (id == R.id.nav_feed) target = new FeedFragment();
             else if (id == R.id.nav_my) target = new MypageFragment();
 
             if (target != null) {
-                switchFragment(target);
+                switchFragment(target, false);
+                showLogoBar(); // 탭 전환 시 항상 로고바
+                bottomNav.setVisibility(View.VISIBLE);
                 return true;
             }
             return false;
         });
-    }
+        // 🔹 상단 뒤로가기 버튼 동작
+        topNav.setNavigationOnClickListener(v -> onBackPressed());
 
-    private void switchFragment(@NonNull Fragment fragment) {
+        // ✅ 새 방식의 뒤로가기 처리
+        getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                handleBackPress();
+            }
+        });
+    }
+    /** 공통 뒤로가기 처리 */
+    private void handleBackPress() {
+        if (getSupportFragmentManager().getBackStackEntryCount() > 0) {
+            getSupportFragmentManager().popBackStack(); // 프래그먼트 뒤로가기
+        } else {
+            finish(); // 앱 종료
+        }
+
+        // 뒤로가기로 복귀할 때 상단바·하단바 상태 복원
+        if (getSupportFragmentManager().getBackStackEntryCount() == 0) {
+            showLogoBar();
+            bottomNav.setVisibility(View.VISIBLE);
+        }
+    }
+    public void switchFragment(@NonNull Fragment fragment, boolean isSubPage) {
         getSupportFragmentManager()
                 .beginTransaction()
                 .replace(R.id.fragmentContainer, fragment)
+                .addToBackStack(isSubPage ? fragment.getClass().getSimpleName() : null)
                 .commit();
+
+        if (isSubPage) {
+            showBackBar(); // 세부화면이면 뒤로가기바로 변경
+            bottomNav.setVisibility(View.GONE); // 하단바 숨김
+        } else {
+            showLogoBar(); // 기본 탭 화면은 로고바
+            bottomNav.setVisibility(View.VISIBLE); // 하단바 표시
+        }
+    }
+
+    /** 🔹 기본 탭 화면: 로고바 */
+    private void showLogoBar() {
+        topNav.setNavigationIcon(null); // 뒤로가기 제거
+        logoContainer.setVisibility(View.VISIBLE); // 로고 표시
+    }
+
+    /** 🔹 세부화면: 뒤로가기바 */
+    private void showBackBar() {
+        topNav.setNavigationIcon(R.drawable.top_bar_go_back);
+        logoContainer.setVisibility(View.GONE); // 로고 숨김
     }
 }

--- a/app/src/main/res/drawable/top_bar_go_back.xml
+++ b/app/src/main/res/drawable/top_bar_go_back.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:tint="#000000" android:viewportHeight="960" android:viewportWidth="960" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M400,720L160,480L400,240L456,298L314,440L800,440L800,520L314,520L456,662L400,720Z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/top_bar_logo.xml
+++ b/app/src/main/res/drawable/top_bar_logo.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M9.4,10.5l4.77,-8.26C13.47,2.09 12.75,2 12,2c-2.4,0 -4.6,0.85 -6.32,2.25l3.66,6.35 0.06,-0.1zM21.54,9c-0.92,-2.92 -3.15,-5.26 -6,-6.34L11.88,9h9.66zM21.8,10h-7.49l0.29,0.5 4.76,8.25C21,16.97 22,14.61 22,12c0,-0.69 -0.07,-1.35 -0.2,-2zM8.54,12l-3.9,-6.75C3.01,7.03 2,9.39 2,12c0,0.69 0.07,1.35 0.2,2h7.49l-1.15,-2zM2.46,15c0.92,2.92 3.15,5.26 6,6.34L12.12,15L2.46,15zM13.73,15l-3.9,6.76c0.7,0.15 1.42,0.24 2.17,0.24 2.4,0 4.6,-0.85 6.32,-2.25l-3.66,-6.35 -0.93,1.6z"/>
+    
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,19 +6,50 @@ xmlns:tools="http://schemas.android.com/tools"
 android:layout_width="match_parent"
 android:layout_height="match_parent"
 tools:context=".MainActivity">
+    <!-- 상단바 -->
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/topNav"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="@color/white"
+        app:titleCentered="true"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:title="">
 
-<!-- 프래그먼트 표시 영역 -->
-<FrameLayout
-    android:id="@+id/fragmentContainer"
+        <!-- 🔸 왼쪽: 로고 자리 (나중에 이미지 교체) -->
+        <LinearLayout
+            android:id="@+id/logoContainer"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingStart="16dp"
+            android:paddingEnd="8dp">
 
-    android:layout_width="0dp"
-    android:layout_height="0dp"
+            <!-- 지금은 placeholder 텍스트로 표시, 나중에 @drawable/app_logo 로 변경 -->
+            <TextView
+                android:id="@+id/logoText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="YourTrip"
+                android:textSize="20sp"
+                android:textStyle="bold"
+                android:textColor="@color/black"/>
+        </LinearLayout>
 
-    app:layout_constraintTop_toTopOf="parent"
-    app:layout_constraintBottom_toTopOf="@+id/bottomNav"
+    </com.google.android.material.appbar.MaterialToolbar>
 
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintEnd_toEndOf="parent"/>
+    <!-- 프래그먼트 표시 영역 -->
+    <FrameLayout
+        android:id="@+id/fragmentContainer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@+id/topNav"
+        app:layout_constraintBottom_toTopOf="@+id/bottomNav"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
     <!-- 🔹 네비게이션 바 (직접 배치) -->
     <com.google.android.material.bottomnavigation.BottomNavigationView


### PR DESCRIPTION
공통 상단 네비게이션 바(로고바 & 뒤로가기바) 구현
- 홈·나의여행·피드·내정보  탭에서 로고바 표시
- 세부화면 진입 시 뒤로가기바로 전환
- 로고 클릭 시 홈으로 이동
