### PR TITLE
낫로그인화면 세로중앙정렬 & 코스리스트 태그 3개 고정

### DIFF
--- a/app/src/main/java/com/example/yourtrip/feed/FeedAddLocationFragment.java
+++ b/app/src/main/java/com/example/yourtrip/feed/FeedAddLocationFragment.java
@@ -1,61 +1,232 @@
 package com.example.yourtrip.feed;
 
 import android.os.Bundle;
+import android.text.Editable;
+import android.text.Html;
+import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.ImageView;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.yourtrip.R;
+import com.example.yourtrip.mytrip.create_direct.PlaceSearchAdapter;
+import com.example.yourtrip.mytrip.create_direct.PlaceSearchManager;
+import com.example.yourtrip.network.NaverSearchResponse;
+
+import java.util.List;
 
 public class FeedAddLocationFragment extends Fragment {
 
-    private EditText editLocation;
+    private EditText etPlaceName;
+    private ImageView btnSearch;
     private Button btnAddLocation;
+    private TextView tvEmptyResult;   // 🔹 추가
+
+
+    private RecyclerView rvPlaces;
+    private PlaceSearchAdapter adapter;
+    private TextView tvTotalCount;
+
+    private NaverSearchResponse.Item selectedPlace = null;
+
+    // ⭐ 버튼 상태 변화 추적
+    private boolean lastEnabledState = false;
 
     @Nullable
     @Override
-    public View onCreateView(@NonNull LayoutInflater inflater,
-                             @Nullable ViewGroup container,
-                             @Nullable Bundle savedInstanceState) {
-
+    public View onCreateView(
+            @NonNull LayoutInflater inflater,
+            @Nullable ViewGroup container,
+            @Nullable Bundle savedInstanceState
+    ) {
         View view = inflater.inflate(R.layout.fragment_feed_add_location, container, false);
 
-        // XML 연결
-        editLocation = view.findViewById(R.id.tv_feed_add_loaction);
-        btnAddLocation = view.findViewById(R.id.btn_feed_add_location);
+        initViews(view);
+        initRecyclerView();
 
-        // “취소하기” 버튼 클릭 → 뒤로가기
+        // 검색 버튼 클릭
+        btnSearch.setOnClickListener(v -> doSearch());
+        btnAddLocation.setOnClickListener(v -> sendSelectedLocation());
+
+        // 취소하기 버튼
         view.findViewById(R.id.btn_feed_cancel_location)
                 .setOnClickListener(v -> requireActivity().onBackPressed());
 
-        // “이 장소 추가하기” 버튼 클릭 처리
-        btnAddLocation.setOnClickListener(v -> {
-            String location = editLocation.getText().toString().trim();
 
-            if (location.isEmpty()) {
-                return; // 빈 값이면 무시
+        // ⭐ 검색창 입력 감지 → 버튼 활성화 처리
+        etPlaceName.addTextChangedListener(new TextWatcher() {
+            @Override public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+            @Override public void afterTextChanged(Editable s) {}
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                updateSearchButtonState();
             }
-
-            // ★ 입력 장소 FeedUploadFragment로 전달
-            Bundle result = new Bundle();
-            result.putString("selected_location", location);
-
-            getParentFragmentManager().setFragmentResult("location_request", result);
-
-            // 이전 화면으로 이동
-            requireActivity().onBackPressed();
         });
+
+        etPlaceName.setOnEditorActionListener((v, actionId, event) -> {
+            // 엔터 또는 Search 액션 눌렀을 때
+            if (actionId == android.view.inputmethod.EditorInfo.IME_ACTION_SEARCH ||
+                    actionId == android.view.inputmethod.EditorInfo.IME_ACTION_DONE) {
+
+                if (btnSearch.isEnabled()) {
+                    btnSearch.performClick();   // 🔹 검색 버튼 자동 클릭
+                }
+                return true;   // 기본 엔터 동작 막기
+            }
+            return false;
+        });
+
+
+        // ⭐ 최초 비활성화
+        btnSearch.setEnabled(false);
+        btnSearch.setColorFilter(
+                getResources().getColor(R.color.gray_300),
+                android.graphics.PorterDuff.Mode.SRC_IN
+        );
 
         return view;
     }
 
-    // 🔻 화면 들어오면 bottomNav 숨김
+    private void initViews(View view) {
+        etPlaceName = view.findViewById(R.id.etPlaceName);
+        btnSearch = view.findViewById(R.id.btnSearch);
+        btnAddLocation = view.findViewById(R.id.btn_feed_add_location);
+
+        rvPlaces = view.findViewById(R.id.rvPlaces);
+        tvTotalCount = view.findViewById(R.id.tvTotalCount);
+        tvEmptyResult = view.findViewById(R.id.tvEmptyResult);   // 🔹 추가
+
+        btnAddLocation.setEnabled(false);
+    }
+
+
+    private void initRecyclerView() {
+        rvPlaces.setLayoutManager(new LinearLayoutManager(requireContext()));
+        adapter = new PlaceSearchAdapter();
+        rvPlaces.setAdapter(adapter);
+
+        adapter.setOnItemClickListener(item -> {
+            selectedPlace = item;
+            btnAddLocation.setEnabled(true);
+        });
+    }
+
+
+    // ⭐ 검색창 입력 → 버튼 활성/비활성 + 애니메이션
+    private void updateSearchButtonState() {
+        boolean hasKeyword = !etPlaceName.getText().toString().trim().isEmpty();
+        boolean enable = hasKeyword;
+
+        // 변화 없으면 처리 안 함
+        if (enable == lastEnabledState) return;
+
+        btnSearch.setEnabled(enable);
+        lastEnabledState = enable;
+
+        if (!enable) {
+            // 비활성 모드
+            btnSearch.setColorFilter(
+                    getResources().getColor(R.color.gray_300),
+                    android.graphics.PorterDuff.Mode.SRC_IN
+            );
+            // 크기 초기화
+            btnSearch.setScaleX(1f);
+            btnSearch.setScaleY(1f);
+            return;
+        }
+
+        // ⭐ 활성화 모드: 파란색 + 확대 애니메이션
+        btnSearch.setColorFilter(
+                getResources().getColor(R.color.blue_main),
+                android.graphics.PorterDuff.Mode.SRC_IN
+        );
+
+        btnSearch.animate()
+                .scaleX(1.18f)
+                .scaleY(1.18f)
+                .setDuration(130)
+                .withEndAction(() ->
+                        btnSearch.animate()
+                                .scaleX(1f)
+                                .scaleY(1f)
+                                .setDuration(130)
+                );
+    }
+
+
+    private void doSearch() {
+        String query = etPlaceName.getText().toString().trim();
+        if (query.isEmpty()) return;
+
+        PlaceSearchManager manager = new PlaceSearchManager(requireContext());
+
+        manager.searchPlaces(query, new PlaceSearchManager.PlaceSearchListener() {
+
+            @Override
+            public void onSuccess(List<NaverSearchResponse.Item> items, int total) {
+                tvEmptyResult.setVisibility(View.GONE);   // 🔹 추가
+
+                tvTotalCount.setText("총 " + total + "개의 검색 결과");
+                tvTotalCount.setVisibility(View.VISIBLE);
+
+                adapter.setItems(items);
+                rvPlaces.setVisibility(View.VISIBLE);
+
+                selectedPlace = null;
+                btnAddLocation.setEnabled(false);
+            }
+
+
+            @Override
+            public void onEmpty() {
+                tvTotalCount.setVisibility(View.GONE);
+                rvPlaces.setVisibility(View.GONE);
+
+                // 🔹 "검색 결과가 없습니다" 문구 표시
+                tvEmptyResult.setVisibility(View.VISIBLE);
+
+                selectedPlace = null;
+                btnAddLocation.setEnabled(false);
+            }
+
+
+            @Override
+            public void onFailure(String errorMessage) {}
+        });
+    }
+
+
+    private void sendSelectedLocation() {
+        if (selectedPlace == null) return;
+
+        String title = Html.fromHtml(
+                selectedPlace.title,
+                Html.FROM_HTML_MODE_LEGACY
+        ).toString();
+
+        Bundle result = new Bundle();
+        result.putString("selected_location", title);
+        result.putString("selected_address", selectedPlace.address);
+        result.putString("selected_link", selectedPlace.link);
+        result.putString("selected_lat", selectedPlace.mapy);
+        result.putString("selected_lng", selectedPlace.mapx);
+
+        getParentFragmentManager().setFragmentResult("location_request", result);
+        requireActivity().onBackPressed();
+    }
+
+
     @Override
     public void onResume() {
         super.onResume();
@@ -63,7 +234,6 @@ public class FeedAddLocationFragment extends Fragment {
         if (bottomNav != null) bottomNav.setVisibility(View.GONE);
     }
 
-    // 🔻 화면 나갈 때 다시 보이게
     @Override
     public void onStop() {
         super.onStop();

--- a/app/src/main/java/com/example/yourtrip/feed/FeedFragment.java
+++ b/app/src/main/java/com/example/yourtrip/feed/FeedFragment.java
@@ -122,6 +122,17 @@ public class FeedFragment extends Fragment {
                 searchFeedList(keyword);
             }
         });
+        // ⭐ 엔터키 → 검색 버튼 자동 클릭
+        etSearch.setOnEditorActionListener((v, actionId, event) -> {
+            if (actionId == android.view.inputmethod.EditorInfo.IME_ACTION_SEARCH ||
+                    actionId == android.view.inputmethod.EditorInfo.IME_ACTION_DONE) {
+
+                btnSearch.performClick();   // 🔹 검색 실행
+                return true;                // 기본 엔터 동작(포커스 이동) 막기
+            }
+            return false;
+        });
+
 
         ImageView btnAddFeed = view.findViewById(R.id.btn_add_feed);
 

--- a/app/src/main/java/com/example/yourtrip/home/HomeSearchFragment.java
+++ b/app/src/main/java/com/example/yourtrip/home/HomeSearchFragment.java
@@ -60,6 +60,19 @@ public class HomeSearchFragment extends Fragment {
         });
 
 
+        etSearch.setOnEditorActionListener((v, actionId, event) -> {
+            if (actionId == android.view.inputmethod.EditorInfo.IME_ACTION_SEARCH ||
+                    actionId == android.view.inputmethod.EditorInfo.IME_ACTION_DONE) {
+
+                if (btnSearch.isEnabled()) {
+                    btnSearch.performClick();   // ⭐ 엔터 → 검색 실행
+                }
+                return true;   // 엔터 기본동작(포커스 이동) 막기
+            }
+            return false;
+        });
+
+
         return view;
     }
 

--- a/app/src/main/java/com/example/yourtrip/home/UploadCourseAdapter.java
+++ b/app/src/main/java/com/example/yourtrip/home/UploadCourseAdapter.java
@@ -69,7 +69,7 @@ public class UploadCourseAdapter extends RecyclerView.Adapter<UploadCourseAdapte
         // 태그 목록
         holder.tagContainer.removeAllViews();
         if (item.keywords != null) {
-            int maxTags = Math.min(item.keywords.size(), 4);  // ⭐ 최대 4개만 보여줌
+            int maxTags = Math.min(item.keywords.size(), 3);  // ⭐ 최대 3개만 보여줌
 
             for (int i = 0; i < maxTags; i++) {
                 String tag = item.keywords.get(i);

--- a/app/src/main/res/layout/activity_not_logged_in.xml
+++ b/app/src/main/res/layout/activity_not_logged_in.xml
@@ -26,7 +26,7 @@
         app:layout_constraintTop_toBottomOf="@id/btn_back"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        android:layout_marginTop="60dp" />
+        android:layout_marginTop="150dp" />
 
     <!-- 안내 문구 -->
     <TextView

--- a/app/src/main/res/layout/fragment_feed_add_location.xml
+++ b/app/src/main/res/layout/fragment_feed_add_location.xml
@@ -3,7 +3,8 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@color/white">
 
     <!-- ▣ 상단바 -->
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -15,7 +16,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">
 
-        <!-- 그만두기 버튼 -->
+        <!-- 취소 버튼 -->
         <TextView
             android:id="@+id/btn_feed_cancel_location"
             android:layout_width="wrap_content"
@@ -24,14 +25,11 @@
             android:layout_marginHorizontal="16dp"
             android:paddingHorizontal="12dp"
             android:gravity="center_vertical"
-
             android:text="취소하기"
             android:textColor="@color/gray_550"
             android:textSize="12sp"
-
             android:clickable="true"
             android:focusable="true"
-
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent" />
@@ -39,7 +37,6 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
             android:gravity="center"
             android:text="장소 추가하기"
             android:textSize="18sp"
@@ -55,11 +52,14 @@
     <!-- 전체 콘텐츠 영역 -->
     <LinearLayout
         android:id="@+id/contentArea"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         android:orientation="vertical"
-        android:paddingHorizontal="16dp"
+        android:paddingHorizontal="20dp"
+        android:paddingTop="16dp"
+        android:paddingBottom="16dp"
         app:layout_constraintTop_toBottomOf="@id/topBar"
+        app:layout_constraintBottom_toTopOf="@id/btn_feed_add_location"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">
 
@@ -67,34 +67,99 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="피드의 장소를 알려주세요"
-            android:textSize="20sp"
+            android:text="피드의 장소를 알려주세요."
+            android:textSize="18sp"
             android:textColor="@color/gray_700"
             android:textStyle="bold"
-            android:layout_marginBottom="24dp"
-            android:layout_marginTop="12dp" />
+            android:layout_marginBottom="20dp"
+            android:layout_marginTop="8dp" />
 
-        <EditText
-            android:id="@+id/tv_feed_add_loaction"
+        <!-- 장소 검색 입력 필드 + 검색 버튼 -->
+        <RelativeLayout
             android:layout_width="match_parent"
-            android:layout_height="56dp"
-            style="@style/RoundedEditText.Default"
-            android:hint="주소나 장소명을 입력해 주세요."
-            android:textSize="16sp"/>
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp">
+
+            <androidx.appcompat.widget.AppCompatEditText
+                android:id="@+id/etPlaceName"
+                style="@style/RoundedEditText.Default"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"
+
+                android:hint="정확한 주소나 장소명을 입력해 주세요."
+                android:textSize="14sp"
+                android:paddingStart="12dp"
+                android:paddingEnd="48dp"
+
+                android:inputType="text"
+                android:maxLines="1"
+                android:singleLine="true"
+                android:imeOptions="actionSearch"
+                />
+
+            <ImageView
+                android:id="@+id/btnSearch"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:layout_alignParentEnd="true"
+                android:layout_centerVertical="true"
+                android:src="@drawable/ic_search"
+                android:padding="8dp"
+                android:background="@android:color/transparent"
+                app:tint="@color/gray_550"
+                />
+
+        </RelativeLayout>
+
+
+        <!-- 검색 결과 수 -->
+        <TextView
+            android:id="@+id/tvTotalCount"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="총 0개의 검색 결과"
+            android:textSize="12sp"
+            android:paddingStart="5dp"
+            android:textColor="@color/gray_550"
+            />
+
+        <!-- 장소 리스트 RecyclerView -->
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="385dp"
+            android:layout_marginTop="5dp"
+            android:background="@drawable/bg_box_border_12dp"
+            android:padding="4dp">
+
+            <TextView
+                android:id="@+id/tvEmptyResult"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="검색 결과가 없습니다."
+                android:textSize="14sp"
+                android:textColor="@color/gray_500"
+                android:paddingTop="12dp"
+                android:visibility="gone"
+                android:layout_gravity="center"/>
+
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rvPlaces"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"/>
+        </FrameLayout>
+
     </LinearLayout>
 
 
-    <!-- ▣ 업로드 버튼 -->
+    <!-- 하단 버튼 -->
     <android.widget.Button
         android:id="@+id/btn_feed_add_location"
         style="@style/ChangeButtonStyle"
-        android:layout_marginHorizontal="16dp"
-        android:layout_marginBottom="40dp"
-        android:layout_marginTop="8dp"
-
+        android:layout_margin="24dp"
         android:text="이 장소 추가하기"
-
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_feed_main.xml
+++ b/app/src/main/res/layout/fragment_feed_main.xml
@@ -81,7 +81,11 @@
                     android:layout_width="match_parent"
                     android:layout_height="48dp"
                     android:hint="장소, 테마, 코스 무엇이든 입력하세요!"
-                    android:textColorHint="@color/gray_550" />
+                    android:textColorHint="@color/gray_550"
+                    android:inputType="text"
+                    android:maxLines="1"
+                    android:singleLine="true"
+                    android:imeOptions="actionSearch"/>
 
                 <ImageView
                     android:id="@+id/btnFeedSearch"

--- a/app/src/main/res/layout/fragment_home_main.xml
+++ b/app/src/main/res/layout/fragment_home_main.xml
@@ -36,9 +36,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="16dp"
-            android:paddingEnd="10dp"
             android:layout_marginBottom="8dp"
-
             app:layout_constraintTop_toBottomOf="@+id/topBar"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent">
@@ -49,7 +47,11 @@
                 android:layout_width="match_parent"
                 android:layout_height="48dp"
                 android:hint="장소, 테마, 코스 무엇이든 입력하세요!"
-                android:textColorHint="@color/gray_550" />
+                android:textColorHint="@color/gray_550"
+                android:imeOptions="actionSearch"
+                android:inputType="text"
+                android:maxLines="1"
+                android:singleLine="true"/>
 
             <ImageView
                 android:layout_width="40dp"

--- a/app/src/main/res/layout/fragment_home_search.xml
+++ b/app/src/main/res/layout/fragment_home_search.xml
@@ -25,7 +25,7 @@
         android:id="@+id/searchContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="16dp"
+        android:layout_marginHorizontal="17dp"
         android:paddingEnd="10dp"
 
         app:layout_constraintTop_toBottomOf="@+id/topBar"
@@ -38,7 +38,11 @@
             android:layout_width="match_parent"
             android:layout_height="48dp"
             android:hint="장소, 테마, 코스 무엇이든 입력하세요!"
-            android:textColorHint="@color/gray_550" />
+            android:textColorHint="@color/gray_550"
+            android:inputType="text"
+            android:maxLines="1"
+            android:singleLine="true"
+            android:imeOptions="actionSearch"/>
 
         <ImageView
             android:id="@+id/btnSearch"

--- a/app/src/main/res/layout/item_readonly_location_card.xml
+++ b/app/src/main/res/layout/item_readonly_location_card.xml
@@ -3,12 +3,12 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="vertical"
+    android:orientation="horizontal"
     android:padding="16dp">
 
     <!-- 상단 영역 (번호, 시간) -->
     <LinearLayout
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:gravity="center_vertical">
@@ -24,26 +24,27 @@
             android:background="@drawable/bg_circle_blue"
             android:textSize="14sp" />
 
-        <!-- 시간 표시 -->
-        <TextView
-            android:id="@+id/tvTime"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:layout_marginStart="16dp"
-            android:text="PM 2:00"
-            android:textSize="12sp"
-            android:textColor="@color/blue_main" />
 
     </LinearLayout>
+
+
 
     <!-- 장소 정보 전체를 감싸는 묶음 -->
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:paddingLeft="40dp"
-        android:layout_marginTop="8dp">
+        android:paddingLeft="10dp">
+
+        <!-- 시간 표시 -->
+        <TextView
+            android:id="@+id/tvTime"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="PM 2:00"
+            android:textSize="12sp"
+            android:textColor="@color/blue_main" />
 
         <!-- 장소 이름 -->
         <TextView


### PR DESCRIPTION
# 🔥 Pull requests

## ✅ 작업 내용
<!-- 작업에 대한 설명을 적어주세요 -->
- 업로드코스의 태그 3개 고정
- 낫로그인화면 세로 정렬
---
- 나의 여행 각 장소카드 레이아웃 수정 -> 시간 없어도 괜찮도록
---
- 피드 장소 검색에 다은님이 연동한거 추가
- 피드 장소검색에 검색 결과 0이면 없다고 문구 추가
- 피드 장소검색에 입력 있을 때만 장소버튼 활성화 & 애니메이션 추가
---
- 홈 검색에 엔터시 자동 검색 
- 피드 검색에 엔터시 자동검색
- 피드 장소검색에 엔터시 자동검색



## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
해당 pull request merge와 함께 이슈를 닫으려면
closed #Issue_number를 적어주세요 -->
